### PR TITLE
Add support of binary payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ cordova.plugins.CordovaMqTTPlugin.connect({
     username:"uname",
     password:'pass',
     keepAlive:60,
+    isBinaryPayload: false, //setting this 'true' will make plugin treat all data as binary and emit ArrayBuffer instead of string on events
     success:function(s){
         console.log("connect success");
     },

--- a/src/android/CordovaMqTTPlugin.java
+++ b/src/android/CordovaMqTTPlugin.java
@@ -1,5 +1,6 @@
 package com.arcoirislabs.plugin.mqtt;
 
+import android.util.Base64;
 import android.util.Log;
 
 import org.apache.cordova.CallbackContext;
@@ -39,7 +40,7 @@ public class CordovaMqTTPlugin extends CordovaPlugin {
                 @Override
                 public void run() {
                     try {
-                        connect(args.getString(0), args.getString(1), args.getInt(2), args.getBoolean(3), args.getInt(4), args.getString(5), args.getString(6), args.getString(7), args.getString(8), args.getInt(9), args.getBoolean(10), args.getString(11));
+                        connect(args.getString(0), args.getString(1), args.getInt(2), args.getBoolean(3), args.getInt(4), args.getString(5), args.getString(6), args.getString(7), args.getString(8), args.getInt(9), args.getBoolean(10), args.getString(11), args.getBoolean(12));
                     } catch (JSONException e) {
                         e.printStackTrace();
                     }
@@ -109,7 +110,7 @@ public class CordovaMqTTPlugin extends CordovaPlugin {
         return false;
     }
 
-    private void connect(String url,String cid,int ka,boolean cleanSess,int connTimeOut,String uname, String pass,String willTopic,String willPayload,int willQos,boolean willRetain,String version) {
+    private void connect(String url,String cid,int ka,boolean cleanSess,int connTimeOut,String uname, String pass,String willTopic,String willPayload,int willQos,boolean willRetain,String version,boolean isBinaryPayload) {
         MemoryPersistence persistence = new MemoryPersistence();
         final MqttConnectOptions connOpts = new MqttConnectOptions();
         connected = false;
@@ -168,8 +169,13 @@ public class CordovaMqTTPlugin extends CordovaPlugin {
                 }
             });
             if (willTopic!=null&&willPayload!=null&&willQos>-1){
-
-                connOpts.setWill(willTopic,willPayload.getBytes(),willQos,willRetain);
+                byte[] willPayloadBytes;
+                if (isBinaryPayload) {
+                    willPayloadBytes = Base64.decode(willPayload, Base64.DEFAULT);
+                } else {
+                    willPayloadBytes = willPayload.getBytes();
+                }
+                connOpts.setWill(willTopic,willPayloadBytes,willQos,willRetain);
             }
 
             if(uname.toString()=="null"&&pass.toString()=="null"){
@@ -221,7 +227,12 @@ public class CordovaMqTTPlugin extends CordovaPlugin {
     }
     private void publish(JSONArray args) throws JSONException {
         final MqttMessage payload = new MqttMessage();
-        payload.setPayload(args.getString(1).getBytes());
+        boolean binaryPayload = args.getBoolean(4);
+        if (binaryPayload) {
+            payload.setPayload(Base64.decode(args.getString(1), Base64.DEFAULT));
+        } else {
+            payload.setPayload(args.getString(1).getBytes());
+        }
         payload.setQos(args.getInt(2));
         payload.setRetained(args.getBoolean(3));
         Log.i("mqttalabs", "Topic is " + args.getString(0) + ". Payload is " + args.getString(1));
@@ -417,4 +428,3 @@ public class CordovaMqTTPlugin extends CordovaPlugin {
     }
 
 }
- 

--- a/src/android/CordovaMqTTPlugin.java
+++ b/src/android/CordovaMqTTPlugin.java
@@ -40,7 +40,7 @@ public class CordovaMqTTPlugin extends CordovaPlugin {
                 @Override
                 public void run() {
                     try {
-                        connect(args.getString(0), args.getString(1), args.getInt(2), args.getBoolean(3), args.getInt(4), args.getString(5), args.getString(6), args.getString(7), args.getString(8), args.getInt(9), args.getBoolean(10), args.getString(11), args.getBoolean(12));
+                        connect(args.getString(0), args.getString(1), args.getInt(2), args.getBoolean(3), args.getInt(4), args.getString(5), args.getString(6), args.getString(7), args.getString(8), args.getInt(9), args.getBoolean(10), args.getString(11), args.getBoolean(12), args.getBoolean(13));
                     } catch (JSONException e) {
                         e.printStackTrace();
                     }
@@ -110,7 +110,7 @@ public class CordovaMqTTPlugin extends CordovaPlugin {
         return false;
     }
 
-    private void connect(String url,String cid,int ka,boolean cleanSess,int connTimeOut,String uname, String pass,String willTopic,String willPayload,int willQos,boolean willRetain,String version,boolean isBinaryPayload) {
+    private void connect(String url,String cid,int ka,boolean cleanSess,int connTimeOut,String uname, String pass,String willTopic,String willPayload,int willQos,boolean willRetain,String version,boolean isBinaryPayload,boolean isBinaryWillPayload) {
         MemoryPersistence persistence = new MemoryPersistence();
         final MqttConnectOptions connOpts = new MqttConnectOptions();
         connected = false;
@@ -147,7 +147,11 @@ public class CordovaMqTTPlugin extends CordovaPlugin {
                     try {
                         dis.put("type", "messageArrived");
                         dis.put("topic", topic);
-                        dis.put("payload", message);
+                        if (isBinaryPayload) {
+                            dis.put("payload", Base64.encodeToString(message.getPayload(), Base64.DEFAULT));
+                        } else {
+                            dis.put("payload", message.toString());
+                        }
                         dis.put("call", "onPublish");
                         dis.put("connectionStatus", client.isConnected());
                         dis.put("qos",message.getQos());
@@ -170,7 +174,7 @@ public class CordovaMqTTPlugin extends CordovaPlugin {
             });
             if (willTopic!=null&&willPayload!=null&&willQos>-1){
                 byte[] willPayloadBytes;
-                if (isBinaryPayload) {
+                if (isBinaryWillPayload) {
                     willPayloadBytes = Base64.decode(willPayload, Base64.DEFAULT);
                 } else {
                     willPayloadBytes = willPayload.getBytes();

--- a/www/cordova-plugin-mqtt.js
+++ b/www/cordova-plugin-mqtt.js
@@ -110,7 +110,7 @@ channel = require('cordova/channel'),
                     }
                 }, function(e){
                     console.error(e);
-                }, "CordovaMqTTPlugin", "connect", [url,args.clientId,(args.keepAlive === undefined ? 60000 : args.keepAlive),iscls,args.connectionTimeout||30,args.username, args.password,args.willTopicConfig.topic,args.willTopicConfig.payload,args.willTopicConfig.qos||0,(args.willTopicConfig.retain === undefined ? true : args.willTopicConfig.retain),args.version||"3.1.1",args.willTopicConfig.payload instanceof ArrayBuffer]);
+                }, "CordovaMqTTPlugin", "connect", [url,args.clientId,(args.keepAlive === undefined ? 60000 : args.keepAlive),iscls,args.connectionTimeout||30,args.username, args.password,args.willTopicConfig.topic,args.willTopicConfig.payload,args.willTopicConfig.qos||0,(args.willTopicConfig.retain === undefined ? true : args.willTopicConfig.retain),args.version||"3.1.1",isBinaryPayload,args.willTopicConfig.payload instanceof ArrayBuffer]);
             } else {
 
                 if (args.url.split("tcp://").length > 1) {


### PR DESCRIPTION
Currently, cordova-plugin-mqtt does not support binary payloads for MQTT messages. It treats all data as strings.
Meanwhile, MQTT standard allows to send and receive binary data, and it can be useful for transmitting Protobuf messages for instance.
This patch adds the support of binary payloads to cordova-plugin-mqtt. Passing ArrayBuffer instead of a string as a payload will make it automatically treated as binary data, and setting 'isBinaryPayload' to 'true' in connection options will emit ArrayBuffer instead of strings on message receive events.