### PR TITLE
Fix issues in 'browser' target

### DIFF
--- a/www/cordova-plugin-mqtt.js
+++ b/www/cordova-plugin-mqtt.js
@@ -107,7 +107,7 @@ channel = require('cordova/channel'),
             } else {
 
                 if (args.url.split("tcp://").length > 1) {
-                    client = new Paho.MQTT.Client(args.url.split("tcp://")[1], Number(args.wsPort), args.urlPath||"/ws", args.clientId);
+                    client = new Paho.MQTT.Client(args.url.split("tcp://")[1], Number(args.wsPort ? args.wsPort : args.port), args.urlPath||"/ws", args.clientId);
                 }
                 // if (args.url.split("local://").length > 1) {
                 //     client = new Paho.MQTT.Client(args.url.split("local://")[1], Number(args.wsPort), args.urlPath||"/ws", args.clientId);

--- a/www/cordova-plugin-mqtt.js
+++ b/www/cordova-plugin-mqtt.js
@@ -154,7 +154,7 @@ channel = require('cordova/channel'),
                 //connOpts.mqttVersion = args.version||"3.1.1";
                 //console.log("will",args.willTopicConfig);
                 if (args.willTopicConfig.topic !== undefined) {
-                    var willMsg = new Paho.MQTT.Message(args.payloadString);
+                    var willMsg = new Paho.MQTT.Message(args.willTopicConfig.payload);
                     willMsg.destinationName = args.willTopicConfig.topic;
                     willMsg.qos = args.willTopicConfig.qos||0;
                     willMsg.retained = (args.willTopicConfig.retain === undefined) ? true : args.willTopicConfig.retain;


### PR DESCRIPTION
Currently, when building cordova-plugin-mqtt with 'browser' target, two significant problems are observed:
1. Constructing new Paho.MQTT.Message in 'connect' method wants to have args.payloadString as a will-payload. Meanwhile, there is no such field in connection options, and that causes 'invalid argument undefined' error on all connection attempts. The correct field is 'args.willTopicConfig.payload'.

2. 'connect' method wants to have 'wsPort' field in connection options. This is absolutely logical because browser-target implementation uses PahoMQTT, that can connect to MQTT broker only via WebSockets protocol. Meanwhile, there are no absolutely no mentions about it in README documentation and omitting this parameter will cause runtime errors too. I think the correct way is to check is 'wsPort' param is present, and if not, use 'port' parameter instead.